### PR TITLE
Override change to interface, various fixes

### DIFF
--- a/src/XlsToEf.Example/ExampleCustomMapperField/ImportProductsFromXlsx.cs
+++ b/src/XlsToEf.Example/ExampleCustomMapperField/ImportProductsFromXlsx.cs
@@ -31,7 +31,7 @@ namespace XlsToEf.Example.ExampleCustomMapperField
 
     }
 
-    public class ProductPropertyOverrider<T> : UpdatePropertyOverrider<T> where T : Product
+    public class ProductPropertyOverrider<T> : IUpdatePropertyOverrider<T> where T : Product
     {
         private readonly DbContext _context;
 
@@ -40,7 +40,7 @@ namespace XlsToEf.Example.ExampleCustomMapperField
             _context = context;
         }
 
-        public override async Task UpdateProperties(T destination1, Dictionary<string, string> matches, Dictionary<string, string> excelRow, RecordMode recordMode)
+        public async Task UpdateProperties(T destination1, Dictionary<string, string> matches, Dictionary<string, string> excelRow, RecordMode recordMode)
         {
             {
                 var product = new Product();

--- a/src/XlsToEf.Example/ExampleCustomMapperField/ImportProductsFromXlsx.cs
+++ b/src/XlsToEf.Example/ExampleCustomMapperField/ImportProductsFromXlsx.cs
@@ -40,7 +40,7 @@ namespace XlsToEf.Example.ExampleCustomMapperField
             _context = context;
         }
 
-        public async Task UpdateProperties(T destination1, Dictionary<string, string> matches, Dictionary<string, string> excelRow, RecordMode recordMode)
+        public async Task<IList<string>> UpdateProperties(T destination1, Dictionary<string, string> matches, Dictionary<string, string> excelRow, RecordMode recordMode)
         {
             {
                 var product = new Product();
@@ -64,6 +64,9 @@ namespace XlsToEf.Example.ExampleCustomMapperField
                         destination1.ProductName = value;
                     }
                 }
+
+                var handledProps = new List<string> { productCategoryPropertyName, productPropertyName };
+                return handledProps;
             }
         }
     }

--- a/src/XlsToEf.Example/Startup.cs
+++ b/src/XlsToEf.Example/Startup.cs
@@ -52,7 +52,7 @@ namespace XlsToEf.Example
             services.Scan(scan => scan
                 .FromAssemblyOf<Address>()
                 .AddClasses(x => x.Where(y => !y.IsAssignableFrom(typeof (XlsToEfDbContext))))
-                .AddClasses(classes => classes.AssignableTo(typeof (UpdatePropertyOverrider<>)))
+                .AddClasses(classes => classes.AssignableTo(typeof (IUpdatePropertyOverrider<>)))
                 .AsImplementedInterfaces()
                 .WithTransientLifetime()
                 );

--- a/src/XlsToEf.Tests/ExcelIoWrapperTests.cs
+++ b/src/XlsToEf.Tests/ExcelIoWrapperTests.cs
@@ -49,5 +49,22 @@ namespace XlsToEf.Tests
                 persianRow["Quantity"].ShouldBe("2");
             }
         }
+
+        public async Task ShouldThrowHelpfulErrorOnMissingSheet()
+        {
+            var excel = new ExcelIoWrapper();
+            var cols =
+                await excel.GetImportColumnData(new XlsxColumnMatcherQuery
+                {
+                    FilePath = AppDomain.CurrentDomain.BaseDirectory + @"\TestExcelDoc.xlsx",
+                    Sheet = "Sheet2"
+                });
+            cols.Count.ShouldBe(2);
+            cols[0].ShouldBe("Cat");
+            cols[1].ShouldBe("Quantity");
+
+            await Should.ThrowAsync<SheetNotFoundException>(async () =>
+                await excel.GetRows("TestExcelDoc.xlsx", "MissingSheet"));
+        }
     }
 }

--- a/src/XlsToEf.Tests/TestPropertyOverriderDbTests.cs
+++ b/src/XlsToEf.Tests/TestPropertyOverriderDbTests.cs
@@ -110,7 +110,7 @@ namespace XlsToEf.Tests
         }
 
 
-        private class ProductPropertyOverrider<T> : UpdatePropertyOverrider<T> where T : Product
+        private class ProductPropertyOverrider<T> : IUpdatePropertyOverrider<T> where T : Product
         {
             private readonly DbContext _context;
 
@@ -119,7 +119,7 @@ namespace XlsToEf.Tests
                 _context = context;
             }
 
-            public override async Task UpdateProperties(T destination1, Dictionary<string, string> matches, Dictionary<string, string> excelRow, RecordMode recordMode)
+            public async Task UpdateProperties(T destination1, Dictionary<string, string> matches, Dictionary<string, string> excelRow, RecordMode recordMode)
             {
                 {
                     var product = new Product();

--- a/src/XlsToEf.Tests/TestPropertyOverriderDbTests.cs
+++ b/src/XlsToEf.Tests/TestPropertyOverriderDbTests.cs
@@ -119,7 +119,7 @@ namespace XlsToEf.Tests
                 _context = context;
             }
 
-            public async Task UpdateProperties(T destination1, Dictionary<string, string> matches, Dictionary<string, string> excelRow, RecordMode recordMode)
+            public async Task<IList<string>> UpdateProperties(T destination1, Dictionary<string, string> matches, Dictionary<string, string> excelRow, RecordMode recordMode)
             {
                 {
                     var product = new Product();
@@ -144,6 +144,8 @@ namespace XlsToEf.Tests
                             destination1.ProductName = value;
                         }
                     }
+                    var handledProps = new List<string> { productCategoryPropertyName, productPropertyName };
+                    return handledProps;
                 }
             }
         }

--- a/src/XlsToEf/Import/SheetNotFoundException.cs
+++ b/src/XlsToEf/Import/SheetNotFoundException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace XlsToEfCore.Import
+namespace XlsToEf.Import
 {
     public class SheetNotFoundException : Exception
     {

--- a/src/XlsToEf/Import/UpdatePropertyOverrider.cs
+++ b/src/XlsToEf/Import/UpdatePropertyOverrider.cs
@@ -1,10 +1,19 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace XlsToEf.Import
 {
+    [Obsolete("Please use interface IUpdatePropertyOverrider")]
     public abstract class UpdatePropertyOverrider<TSelector>
     {
-        public abstract Task UpdateProperties(TSelector destination, Dictionary<string, string> destinationProperty, Dictionary<string, string> value, RecordMode recordMode);
+        public abstract Task UpdateProperties(TSelector destination, Dictionary<string, string> destinationProperty,
+            Dictionary<string, string> value, RecordMode recordMode);
+    }
+
+    public interface IUpdatePropertyOverrider<in TSelector>
+    {
+        Task UpdateProperties(TSelector destination, Dictionary<string, string> destinationProperty,
+            Dictionary<string, string> value, RecordMode recordMode);
     }
 }

--- a/src/XlsToEf/Import/UpdatePropertyOverrider.cs
+++ b/src/XlsToEf/Import/UpdatePropertyOverrider.cs
@@ -4,16 +4,27 @@ using System.Threading.Tasks;
 
 namespace XlsToEf.Import
 {
-    [Obsolete("Please use interface IUpdatePropertyOverrider")]
+    [Obsolete("Please use interface IUpdatePropertyOverrider", true)]
     public abstract class UpdatePropertyOverrider<TSelector>
     {
         public abstract Task UpdateProperties(TSelector destination, Dictionary<string, string> destinationProperty,
             Dictionary<string, string> value, RecordMode recordMode);
     }
 
-    public interface IUpdatePropertyOverrider<in TSelector>
+    public interface IUpdatePropertyOverrider<in TEntity>
     {
-        Task UpdateProperties(TSelector destination, Dictionary<string, string> destinationProperty,
-            Dictionary<string, string> value, RecordMode recordMode);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="TEntity">The type of EF Entity</typeparam>
+        /// <param name="destination">Destination entity to save data to</param>
+        /// <param name="matches">Dictionary containing the entity destination property name as key, and the excel field name as the value</param>
+        /// <param name="excelRow">dictionary containing all of the incoming excel data, key is excel field name</param>
+        /// <param name="recordMode">value of RecordMode enumeration to allow implementation to obey recordMode that was set</param>
+        /// <returns>Return list should be a collection of the entity destination property names
+        /// for all properties that should be considered already handled by the overrider. The system will handle the
+        /// remaining mapped properties </returns>
+       Task<IList<string>> UpdateProperties(TEntity destination, Dictionary<string, string> matches, Dictionary<string, string> excelRow, RecordMode recordMode);
+
     }
 }

--- a/src/XlsToEf/Import/XlsxToTableImporter.cs
+++ b/src/XlsToEf/Import/XlsxToTableImporter.cs
@@ -68,23 +68,28 @@ namespace XlsToEf.Import
             }
 
             var selectedDict = BuildDictionaryFromSelected(matchingData.Selected);
+            var isAutoIncrementingId = IsIdAutoIncrementing(typeof(TEntity));
 
             var keyInfo =  GetEntityKeys(typeof (TEntity));
             EnsureImportingEntityHasSingleKey(keyInfo);
             var pk = keyInfo[0];
-            Type idType = ((PrimitiveType) pk.TypeUsage.EdmType).ClrEquivalentType;
 
+            ValidateIdTypes<TEntity, TId>(idPropertyName, pk);
 
+            var isImportingEntityId = selectedDict.ContainsKey(pk.Name);
+            EnsureNoIdColumnIncludedWhenCreatingAutoIncrementEntities(saveBehavior.RecordMode, isAutoIncrementingId, isImportingEntityId);
+            
             if (idPropertyName == null)
             {
                 idPropertyName = pk.Name;
             }
 
-            var isImportingEntityId = selectedDict.ContainsKey(idPropertyName);
-            var isAutoIncrementingId = IsIdAutoIncrementing(typeof(TEntity));
+            var isImportingMatchableEntities = selectedDict.ContainsKey(idPropertyName);
 
-            EnsureNoIdColumnIncludedWhenCreatingAutoIncrementEntities(saveBehavior.RecordMode, isAutoIncrementingId, isImportingEntityId);
-            
+            Type trueIdType = ((PrimitiveType)pk.TypeUsage.EdmType).ClrEquivalentType;
+
+
+
             var importResult = new ImportResult {RowErrorDetails = new Dictionary<string, string>()};
 
             var excelRows = await GetExcelRows(matchingData, fileLocation);
@@ -100,24 +105,28 @@ namespace XlsToEf.Import
                     if (ExcelRowIsBlank(excelRow))
                         continue;
 
-                    string idValue = null;
-                    if (isImportingEntityId)
+                    if (isImportingMatchableEntities)
                     {
                         var xlsxIdColName = selectedDict[idPropertyName];
                         var idStringValue = excelRow[xlsxIdColName];
-                        entityToUpdate = await GetMatchedDbObject(finder, idStringValue, idType);
+                        entityToUpdate = await GetMatchedDbObject(finder, idStringValue, trueIdType);
 
                         ValidateDbResult(entityToUpdate, saveBehavior.RecordMode, xlsxIdColName, idStringValue);
                     }
 
                     if (entityToUpdate == null)
                     {
-                        EnsureNoEntityCreationWithIdWhenAutoIncrementIdType(idPropertyName, isAutoIncrementingId, idValue);
+                        if (selectedDict.ContainsKey(pk.Name))
+                        {
+                            var trueIdXlsxIdFieldName = selectedDict[pk.Name];
+                            EnsureNoEntityCreationWithIdWhenAutoIncrementIdType(pk.Name, isAutoIncrementingId, excelRow[trueIdXlsxIdFieldName]);
+                        }
+
                         entityToUpdate = new TEntity();
                         _dbContext.Set<TEntity>().Add(entityToUpdate);
                     }
 
-                    await MapIntoEntity(selectedDict, idPropertyName, overridingMapper, entityToUpdate, excelRow, isAutoIncrementingId, saveBehavior.RecordMode);
+                    await MapIntoEntity(selectedDict, pk.Name, overridingMapper, entityToUpdate, excelRow, isAutoIncrementingId, saveBehavior.RecordMode);
                     if (validator != null)
                     {
                         var errors = validator.GetValidationErrors(entityToUpdate);
@@ -159,6 +168,17 @@ namespace XlsToEf.Import
             }
 
             return importResult;
+        }
+
+        private void ValidateIdTypes<TEntity, TId>(string idPropertyName, EdmMember pk) where TEntity : class, new()
+        {
+            if (idPropertyName != null)
+            {
+                var alternateCol = GetEntityProperty(typeof(TEntity), idPropertyName);
+                var idType = alternateCol.GetType();
+                if (idType != typeof(TId))
+                    throw new Exception("If using Surrogate ID, TId Type must be type of Surrogate ID");
+            }
         }
 
         private async Task<List<Dictionary<string, string>>> GetExcelRows(DataMatchesForImport matchingData, string fileLocation)
@@ -208,17 +228,18 @@ namespace XlsToEf.Import
         }
 
         private static async Task MapIntoEntity<TEntity>(Dictionary<string, string> matchingData, string idPropertyName,
-            IUpdatePropertyOverrider<TEntity> overridingMapper, TEntity entityToUpdate, Dictionary<string, string> excelRow, bool isAutoIncrementingId, RecordMode recordMode)
-            
+            IUpdatePropertyOverrider<TEntity> overridingMapper, TEntity entityToUpdate,
+            Dictionary<string, string> excelRow, bool isAutoIncrementingId, RecordMode recordMode)
+
         {
+            IList<string> alreadyHandledPropertyNames = new List<string>();
             if (overridingMapper != null)
             {
-                await overridingMapper.UpdateProperties(entityToUpdate, matchingData, excelRow, recordMode);
+                alreadyHandledPropertyNames =
+                    await overridingMapper.UpdateProperties(entityToUpdate, matchingData, excelRow, recordMode);
             }
-            else
-            {
-                UpdateProperties(entityToUpdate, matchingData, excelRow, idPropertyName, isAutoIncrementingId);
-            }
+            UpdateProperties(entityToUpdate, matchingData, excelRow, idPropertyName, isAutoIncrementingId, alreadyHandledPropertyNames);
+
         }
 
         // this condition might happen when Upserting. unlike the other check, this check is per-row.
@@ -313,6 +334,16 @@ namespace XlsToEf.Import
             return entityType.KeyMembers;
         }
 
+        private EdmProperty GetEntityProperty(Type eType, string propName)
+        {
+            var metadata = ((IObjectContextAdapter)_dbContext).ObjectContext.MetadataWorkspace;
+
+            var objectItemCollection = ((ObjectItemCollection)metadata.GetItemCollection(DataSpace.OSpace));
+            var entityType = metadata.GetItems<EntityType>(DataSpace.OSpace).Single(e => objectItemCollection.GetClrType(e) == eType);
+            var prop = entityType.Properties.FirstOrDefault(x => x.Name == propName);
+            return prop;
+        }
+
         private EdmMember GetMappedKeyInformation(Type eType)
         {
             var metadata = ((IObjectContextAdapter) _dbContext).ObjectContext.MetadataWorkspace;
@@ -349,10 +380,11 @@ namespace XlsToEf.Import
         }
 
         private static void UpdateProperties<TSelector>(TSelector matchedObject, Dictionary<string, string> matches,
-            Dictionary<string, string> excelRow, string selectorColName, bool shouldSkipIdInsert) 
+            Dictionary<string, string> excelRow, string selectorColName, bool shouldSkipIdInsert, IList<string> alreadyHandledPropertyNames) 
         {
             foreach (var entityPropertyName in matches.Keys)
             {
+                if (alreadyHandledPropertyNames.Contains(entityPropertyName)) continue;
                 if ((entityPropertyName == selectorColName) && shouldSkipIdInsert) continue;
                 var xlsxColumnName = matches[entityPropertyName];
                 var xlsxItemData = excelRow[xlsxColumnName];

--- a/src/XlsToEfCore.Example/ExampleCustomMapperField/ImportProductsFromXlsx.cs
+++ b/src/XlsToEfCore.Example/ExampleCustomMapperField/ImportProductsFromXlsx.cs
@@ -31,7 +31,7 @@ namespace XlsToEfCore.Example.ExampleCustomMapperField
 
     }
 
-    public class ProductPropertyOverrider<T> : UpdatePropertyOverrider<T> where T : Product
+    public class ProductPropertyOverrider<T> : IUpdatePropertyOverrider<T> where T : Product
     {
         private readonly DbContext _context;
 
@@ -40,7 +40,7 @@ namespace XlsToEfCore.Example.ExampleCustomMapperField
             _context = context;
         }
 
-        public override async Task UpdateProperties(T destination1, Dictionary<string, string> matches, Dictionary<string, string> excelRow, RecordMode recordMode)
+        public async Task UpdateProperties(T destination1, Dictionary<string, string> matches, Dictionary<string, string> excelRow, RecordMode recordMode)
         {
             {
                 var product = new Product();

--- a/src/XlsToEfCore.Example/ExampleCustomMapperField/ImportProductsFromXlsx.cs
+++ b/src/XlsToEfCore.Example/ExampleCustomMapperField/ImportProductsFromXlsx.cs
@@ -40,31 +40,33 @@ namespace XlsToEfCore.Example.ExampleCustomMapperField
             _context = context;
         }
 
-        public async Task UpdateProperties(T destination1, Dictionary<string, string> matches, Dictionary<string, string> excelRow, RecordMode recordMode)
+        public async Task<IList<string>> UpdateProperties(T destination1, Dictionary<string, string> matches,
+            Dictionary<string, string> excelRow, RecordMode recordMode)
         {
-            {
-                var product = new Product();
-                var productCategoryPropertyName = "ProductCategoryCode";
-                var productPropertyName = PropertyNameHelper.GetPropertyName(() => product.ProductName);
+            var product = new Product();
+            var productCategoryPropertyName = "ProductCategoryCode";
+            var productPropertyName = PropertyNameHelper.GetPropertyName(() => product.ProductName);
 
-                foreach (var destinationProperty in matches.Keys)
+            foreach (var destinationProperty in matches.Keys)
+            {
+                var xlsxColumnName = matches[destinationProperty];
+                var value = excelRow[xlsxColumnName];
+                if (destinationProperty == productCategoryPropertyName)
                 {
-                    var xlsxColumnName = matches[destinationProperty];
-                    var value = excelRow[xlsxColumnName];
-                    if (destinationProperty == productCategoryPropertyName)
-                    {
-                        var newCategory =
-                            await _context.Set<ProductCategory>().Where(x => x.CategoryCode == value).FirstOrDefaultAsync();
-                        if (newCategory == null)
-                            throw new RowParseException("Category Code does not match a category");
-                        destination1.ProductCategory = newCategory;
-                    }
-                    else if (destinationProperty == productPropertyName)
-                    {
-                        destination1.ProductName = value;
-                    }
+                    var newCategory =
+                        await _context.Set<ProductCategory>().Where(x => x.CategoryCode == value).FirstOrDefaultAsync();
+                    if (newCategory == null)
+                        throw new RowParseException("Category Code does not match a category");
+                    destination1.ProductCategory = newCategory;
+                }
+                else if (destinationProperty == productPropertyName)
+                {
+                    destination1.ProductName = value;
                 }
             }
+
+            var handledProps = new List<string> {productCategoryPropertyName, productPropertyName};
+            return handledProps;
         }
     }
 }

--- a/src/XlsToEfCore.Example/Startup.cs
+++ b/src/XlsToEfCore.Example/Startup.cs
@@ -42,7 +42,7 @@ namespace XlsToEfCore.Example
             services.Scan(scan => scan
                 .FromAssemblyOf<Address>()
                 .AddClasses(x => x.Where(y => !y.IsAssignableFrom(typeof(XlsToEfDbContext))))
-                .AddClasses(classes => classes.AssignableTo(typeof(UpdatePropertyOverrider<>)))
+                .AddClasses(classes => classes.AssignableTo(typeof(IUpdatePropertyOverrider<>)))
                 .AsImplementedInterfaces()
                 .WithTransientLifetime()
             );

--- a/src/XlsToEfCore.Tests/DbTestBase.cs
+++ b/src/XlsToEfCore.Tests/DbTestBase.cs
@@ -1,6 +1,7 @@
 using System.Configuration;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using XlsToEfCore.Tests.Infrastructure;
 using Microsoft.Extensions.Configuration;
 
@@ -18,13 +19,13 @@ namespace XlsToEfCore.Tests
             return new XlsToEfDbContext(optionsBuilder.Options);
         }
 
-        protected async Task PersistToDatabase<T>(T entity)
+        protected async Task PersistToDatabase<T>(params T[] entity)
         where T: class
         {
             using (var db = GetDb())
             {
-
-                await db.Set<T>().AddAsync(entity);
+                foreach (var e in entity)
+                    await db.Set<T>().AddAsync(e);
 
                 await db.SaveChangesAsync();
             }

--- a/src/XlsToEfCore.Tests/ExcelIoWrapperTests.cs
+++ b/src/XlsToEfCore.Tests/ExcelIoWrapperTests.cs
@@ -15,10 +15,10 @@ namespace XlsToEfCore.Tests
             var excel = new ExcelIoWrapper();
             var cols =
                 await excel.GetImportColumnData(new XlsxColumnMatcherQuery
-                    {
-                        FilePath = AppDomain.CurrentDomain.BaseDirectory + @"\TestExcelDoc.xlsx",
-                        Sheet = "Sheet2"
-                    });
+                {
+                    FilePath = AppDomain.CurrentDomain.BaseDirectory + @"\TestExcelDoc.xlsx",
+                    Sheet = "Sheet2"
+                });
             cols.Count.ShouldBe(2);
             cols[0].ShouldBe("Cat");
             cols[1].ShouldBe("Quantity");
@@ -31,23 +31,39 @@ namespace XlsToEfCore.Tests
         public async Task ShouldGetFromSpreadsheetUsingStream()
         {
             var excel = new ExcelIoWrapper();
-            using (var stream = new FileInfo(AppDomain.CurrentDomain.BaseDirectory + @"\TestExcelDoc.xlsx").OpenRead())
-            {
-                var cols =
-                    await excel.GetImportColumnData(new XlsxColumnMatcherQuery
-                    {
-                        FileStream = stream,
-                        Sheet = "Sheet2"
-                    });
+            await using var stream =
+                new FileInfo(AppDomain.CurrentDomain.BaseDirectory + @"\TestExcelDoc.xlsx").OpenRead();
+            var cols =
+                await excel.GetImportColumnData(new XlsxColumnMatcherQuery
+                {
+                    FileStream = stream,
+                    Sheet = "Sheet2"
+                });
 
-                cols.Count.ShouldBe(2);
-                cols[0].ShouldBe("Cat");
-                cols[1].ShouldBe("Quantity");
-                var rows = await excel.GetRows(stream, "Sheet2");
-                rows.Count.ShouldBe(3);
-                var persianRow = rows.Single(x => x["Cat"] == "Persian");
-                persianRow["Quantity"].ShouldBe("2");
-            }
+            cols.Count.ShouldBe(2);
+            cols[0].ShouldBe("Cat");
+            cols[1].ShouldBe("Quantity");
+            var rows = await excel.GetRows(stream, "Sheet2");
+            rows.Count.ShouldBe(3);
+            var persianRow = rows.Single(x => x["Cat"] == "Persian");
+            persianRow["Quantity"].ShouldBe("2");
+        }
+
+        public async Task ShouldThrowHelpfulErrorOnMissingSheet()
+        {
+            var excel = new ExcelIoWrapper();
+            var cols =
+                await excel.GetImportColumnData(new XlsxColumnMatcherQuery
+                {
+                    FilePath = AppDomain.CurrentDomain.BaseDirectory + @"\TestExcelDoc.xlsx",
+                    Sheet = "Sheet2"
+                });
+            cols.Count.ShouldBe(2);
+            cols[0].ShouldBe("Cat");
+            cols[1].ShouldBe("Quantity");
+
+            await Should.ThrowAsync<SheetNotFoundException>(async () =>
+                await excel.GetRows("TestExcelDoc.xlsx", "MissingSheet"));
         }
     }
 }

--- a/src/XlsToEfCore.Tests/TestPropertyOverriderDbTests.cs
+++ b/src/XlsToEfCore.Tests/TestPropertyOverriderDbTests.cs
@@ -185,32 +185,33 @@ namespace XlsToEfCore.Tests
                 _context = context;
             }
 
-            public async Task UpdateProperties(T destination1, Dictionary<string, string> matches, Dictionary<string, string> excelRow, RecordMode recordMode)
+            public async Task<IList<string>> UpdateProperties(T destination1, Dictionary<string, string> matches,
+                Dictionary<string, string> excelRow, RecordMode recordMode)
             {
-                {
-                    var product = new Product();
-                    var productCategoryPropertyName =
-                        PropertyNameHelper.GetPropertyName(() => product.ProductCategory);
-                    var productPropertyName = PropertyNameHelper.GetPropertyName(() => product.ProductName);
 
-                    foreach (var destinationProperty in matches.Keys)
+                var product = new Product();
+                var productCategoryPropertyName = PropertyNameHelper.GetPropertyName(() => product.ProductCategory);
+                var productPropertyName = PropertyNameHelper.GetPropertyName(() => product.ProductName);
+
+                foreach (var destinationProperty in matches.Keys)
+                {
+                    var xlsxColumnName = matches[destinationProperty];
+                    var value = excelRow[xlsxColumnName];
+                    if (destinationProperty == productCategoryPropertyName)
                     {
-                        var xlsxColumnName = matches[destinationProperty];
-                        var value = excelRow[xlsxColumnName];
-                        if (destinationProperty == productCategoryPropertyName)
-                        {
-                            var newCategory =
-                                await _context.Set<ProductCategory>().Where(x => x.CategoryCode == value).FirstAsync();
-                            if (newCategory == null)
-                                throw new RowParseException("Category Code does not match a category");
-                            destination1.ProductCategory = newCategory;
-                        }
-                        else if (destinationProperty == productPropertyName)
-                        {
-                            destination1.ProductName = value;
-                        }
+                        var newCategory =
+                            await _context.Set<ProductCategory>().Where(x => x.CategoryCode == value).FirstAsync();
+                        if (newCategory == null)
+                            throw new RowParseException("Category Code does not match a category");
+                        destination1.ProductCategory = newCategory;
+                    }
+                    else if (destinationProperty == productPropertyName)
+                    {
+                        destination1.ProductName = value;
                     }
                 }
+                var handledProps = new List<string> { productCategoryPropertyName, productPropertyName };
+                return handledProps;
             }
         }
     }

--- a/src/XlsToEfCore.Tests/TestPropertyOverriderDbTests.cs
+++ b/src/XlsToEfCore.Tests/TestPropertyOverriderDbTests.cs
@@ -110,7 +110,7 @@ namespace XlsToEfCore.Tests
         }
 
 
-        private class ProductPropertyOverrider<T> : UpdatePropertyOverrider<T> where T : Product
+        private class ProductPropertyOverrider<T> : IUpdatePropertyOverrider<T> where T : Product
         {
             private readonly DbContext _context;
 
@@ -119,7 +119,7 @@ namespace XlsToEfCore.Tests
                 _context = context;
             }
 
-            public override async Task UpdateProperties(T destination1, Dictionary<string, string> matches, Dictionary<string, string> excelRow, RecordMode recordMode)
+            public async Task UpdateProperties(T destination1, Dictionary<string, string> matches, Dictionary<string, string> excelRow, RecordMode recordMode)
             {
                 {
                     var product = new Product();

--- a/src/XlsToEfCore/Import/ExcelIoWrapper.cs
+++ b/src/XlsToEfCore/Import/ExcelIoWrapper.cs
@@ -54,6 +54,8 @@ namespace XlsToEfCore.Import
             {
                 using (var excel = new ExcelPackage(fileStream))
                 {
+                    EnsureSheetExists(sheetName, excel);
+
                     var sheet = excel.Workbook.Worksheets.First(x => x.Name == sheetName);
                     var headerCells =
                         sheet.Cells[
@@ -63,6 +65,12 @@ namespace XlsToEfCore.Import
             });
 
             return colNames;
+        }
+
+        private static void EnsureSheetExists(string sheetName, ExcelPackage excel)
+        {
+            if (excel.Workbook.Worksheets.All(x => x.Name != sheetName))
+                throw new SheetNotFoundException(sheetName);
         }
 
         public Task<IList<string>> GetImportColumnData(XlsxColumnMatcherQuery matcherQuery)
@@ -87,6 +95,8 @@ namespace XlsToEfCore.Import
             {
                 using (var excel = new ExcelPackage(fileStream))
                 {
+                    EnsureSheetExists(sheetName, excel);
+
                     var sheet = excel.Workbook.Worksheets.First(x => x.Name == sheetName);
 
 

--- a/src/XlsToEfCore/Import/ExcelIoWrapper.cs
+++ b/src/XlsToEfCore/Import/ExcelIoWrapper.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -98,7 +97,6 @@ namespace XlsToEfCore.Import
                     EnsureSheetExists(sheetName, excel);
 
                     var sheet = excel.Workbook.Worksheets.First(x => x.Name == sheetName);
-
 
                     var rows = new List<Dictionary<string, string>>();
 

--- a/src/XlsToEfCore/Import/RowInvalidException.cs
+++ b/src/XlsToEfCore/Import/RowInvalidException.cs
@@ -5,7 +5,6 @@ using System.Linq;
 namespace XlsToEfCore.Import
 {
     public class RowInvalidException : Exception
-
     {
         public RowInvalidException(Dictionary<string, string> details) : base(MakeString(details))
         {

--- a/src/XlsToEfCore/Import/SheetNotFoundException.cs
+++ b/src/XlsToEfCore/Import/SheetNotFoundException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace XlsToEfCore.Import
+{
+    public class SheetNotFoundException : Exception
+    {
+        public SheetNotFoundException(string sheetName) : base(MakeString(sheetName))
+        {
+        }
+
+        private static string MakeString(string sheetName)
+        {
+            return $"Sheet {sheetName} not found in spreadsheet";
+        }
+    }
+}

--- a/src/XlsToEfCore/Import/UpdatePropertyOverrider.cs
+++ b/src/XlsToEfCore/Import/UpdatePropertyOverrider.cs
@@ -4,14 +4,25 @@ using System.Threading.Tasks;
 
 namespace XlsToEfCore.Import
 {
-    [Obsolete("Please use interface IUpdatePropertyOverrider")]
+    [Obsolete("Please use interface IUpdatePropertyOverrider", true)]
     public abstract class UpdatePropertyOverrider<TSelector>
     {
         public abstract Task UpdateProperties(TSelector destination, Dictionary<string, string> destinationProperty, Dictionary<string, string> value, RecordMode recordMode);
     }
 
-    public interface IUpdatePropertyOverrider<in TSelector>
+    public interface IUpdatePropertyOverrider<in TEntity>
     {
-        Task UpdateProperties(TSelector destination, Dictionary<string, string> destinationProperty, Dictionary<string, string> value, RecordMode recordMode);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="TEntity">The type of EF Entity</typeparam>
+        /// <param name="destination">Destination entity to save data to</param>
+        /// <param name="matches">Dictionary containing the entity destination property name as key, and the excel field name as the value</param>
+        /// <param name="excelRow">dictionary containing all of the incoming excel data, key is excel field name</param>
+        /// <param name="recordMode">value of RecordMode enumeration to allow implementation to obey recordMode that was set</param>
+        /// <returns>Return list should be a collection of the entity destination property names
+        /// for all properties that should be considered already handled by the overrider. The system will handle the
+        /// remaining mapped properties </returns>
+        Task<IList<string>> UpdateProperties(TEntity destination, Dictionary<string, string> matches, Dictionary<string, string> excelRow, RecordMode recordMode);
     }
 }

--- a/src/XlsToEfCore/Import/UpdatePropertyOverrider.cs
+++ b/src/XlsToEfCore/Import/UpdatePropertyOverrider.cs
@@ -1,10 +1,17 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace XlsToEfCore.Import
 {
+    [Obsolete("Please use interface IUpdatePropertyOverrider")]
     public abstract class UpdatePropertyOverrider<TSelector>
     {
         public abstract Task UpdateProperties(TSelector destination, Dictionary<string, string> destinationProperty, Dictionary<string, string> value, RecordMode recordMode);
+    }
+
+    public interface IUpdatePropertyOverrider<in TSelector>
+    {
+        Task UpdateProperties(TSelector destination, Dictionary<string, string> destinationProperty, Dictionary<string, string> value, RecordMode recordMode);
     }
 }

--- a/src/XlsToEfCore/Import/XlsxToTableImporter.cs
+++ b/src/XlsToEfCore/Import/XlsxToTableImporter.cs
@@ -167,12 +167,13 @@ namespace XlsToEfCore.Import
 
         private void ValidateIdTypes<TEntity, TId>(string idPropertyName, IProperty pk) where TEntity : class, new()
         {
-            if (idPropertyName != null){
-            var alternateCol = GetEntityProperty(typeof(TEntity), idPropertyName);
+            if (idPropertyName != null)
+            {
+                var alternateCol = GetEntityProperty(typeof(TEntity), idPropertyName);
                 var idType = alternateCol.PropertyInfo.PropertyType;
                 if (idType != typeof(TId))
                     throw new Exception("If using Surrogate ID, TId Type must be type of Surrogate ID");
-                }
+            }
         }
 
         private Task<List<Dictionary<string, string>>> GetExcelRows(DataMatchesForImport matchingData, string fileLocation)
@@ -316,9 +317,9 @@ namespace XlsToEfCore.Import
             return keys;
         }
 
-        private IProperty GetEntityProperty(Type eType, string column)
+        private IProperty GetEntityProperty(Type eType, string propName)
         {
-            var prop = _dbContext.Model.FindEntityType(eType).FindProperty(column);
+            var prop = _dbContext.Model.FindEntityType(eType).FindProperty(propName);
             return prop;
         }
 

--- a/src/XlsToEfCore/Import/XlsxToTableImporter.cs
+++ b/src/XlsToEfCore/Import/XlsxToTableImporter.cs
@@ -78,7 +78,8 @@ namespace XlsToEfCore.Import
                 idPropertyName = pk.Name;
             }
 
-            var isImportingEntityId = selectedDict.ContainsKey(idPropertyName);
+            var isImportingEntityId = selectedDict.ContainsKey(pk.Name);
+            var isImportingMatchedEntities = selectedDict.ContainsKey(idPropertyName);
             var isDbGeneratedId = IsIdDbGenerated(typeof(TEntity));
 
             EnsureNoIdColumnIncludedWhenCreatingAutoIncrementEntities(saveBehavior.RecordMode, isDbGeneratedId, isImportingEntityId);
@@ -99,7 +100,7 @@ namespace XlsToEfCore.Import
                         continue;
 
                     string idValue = null;
-                    if (isImportingEntityId)
+                    if (isImportingMatchedEntities)
                     {
                         var xlsxIdColName = selectedDict[idPropertyName];
                         var idStringValue = excelRow[xlsxIdColName];


### PR DESCRIPTION
For both XlsToEf and XlsToEfCore

Breaking Changes:
Change override base class to interface
change override to return list of property names that were already handled 

Improvement:
Better errors around not found sheet

Improvement/Breaking
When using an overrider, Application will now update properties not in the list returned from the overrider. This way overriding one field will mean you don't have to manually map the rest of the fields.
